### PR TITLE
Reduce the number of fallible constructors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,21 @@
+# Changelog
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+### Added
+- `GEMINI_MIME_STR`, the `&str` representation of the Gemini MIME
+- `Meta::new_lossy` constructor that never fails
+- "lossy" constructors for `Response` and `Status` (see `Meta::new_lossy`)
+
+### Changed
+- Some `Response` and `Status` constructors are now infallible
+
+### Deprecated
+- Instead of `gemini_mime()` use `GEMINI_MIME`
+
+## [0.2.0] - 2020-11-14
+### Added
+- Access to client certificates by [@Alch-Emi](https://github.com/Alch-Emi)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,9 +8,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - `GEMINI_MIME_STR`, the `&str` representation of the Gemini MIME
 - `Meta::new_lossy` constructor that never fails
+- `Meta::MAX_LEN`, which is `1024`
 - "lossy" constructors for `Response` and `Status` (see `Meta::new_lossy`)
 
 ### Changed
+- `Meta::new` rejects strings exceeding `Meta::MAX_LEN` (`1024`)
 - Some `Response` and `Status` constructors are now infallible
 
 ### Deprecated

--- a/examples/certificates.rs
+++ b/examples/certificates.rs
@@ -32,7 +32,7 @@ fn handle_request(users: Arc<RwLock<HashMap<CertBytes, String>>>, request: Reque
             if let Some(user) = users_read.get(cert_bytes) {
                 // The user has already registered
                 Ok(
-                    Response::success(&GEMINI_MIME)?
+                    Response::success(&GEMINI_MIME)
                         .with_body(format!("Welcome {}!", user))
                 )
             } else {
@@ -44,7 +44,7 @@ fn handle_request(users: Arc<RwLock<HashMap<CertBytes, String>>>, request: Reque
                     let mut users_write = users.write().await;
                     users_write.insert(cert_bytes.clone(), username.to_owned());
                     Ok(
-                        Response::success(&GEMINI_MIME)?
+                        Response::success(&GEMINI_MIME)
                             .with_body(format!(
                                 "Your account has been created {}!  Welcome!",
                                 username
@@ -57,7 +57,7 @@ fn handle_request(users: Arc<RwLock<HashMap<CertBytes, String>>>, request: Reque
             }
         } else {
             // The user didn't provide a certificate
-            Response::client_certificate_required()
+            Ok(Response::client_certificate_required())
         }
     }.boxed()
 }

--- a/src/types.rs
+++ b/src/types.rs
@@ -88,11 +88,18 @@ impl ResponseHeader {
         })
     }
 
-    pub fn success(mime: &Mime) -> Result<Self> {
-        Ok(Self {
+    pub fn input_lossy(prompt: impl AsRef<str> + Into<String>) -> Self {
+        Self {
+            status: Status::INPUT,
+            meta: Meta::new_lossy(prompt),
+        }
+    }
+
+    pub fn success(mime: &Mime) -> Self {
+        Self {
             status: Status::SUCCESS,
-            meta: Meta::new(mime.to_string())?,
-        })
+            meta: Meta::new_lossy(mime.to_string()),
+        }
     }
 
     pub fn server_error(reason: impl AsRef<str> + Into<String>) -> Result<Self> {
@@ -102,25 +109,32 @@ impl ResponseHeader {
         })
     }
 
-    pub fn not_found() -> Result<Self> {
-        Ok(Self {
+    pub fn server_error_lossy(reason: impl AsRef<str> + Into<String>) -> Self {
+        Self {
+            status: Status::PERMANENT_FAILURE,
+            meta: Meta::new_lossy(reason),
+        }
+    }
+
+    pub fn not_found() -> Self {
+        Self {
             status: Status::NOT_FOUND,
-            meta: Meta::new("Not found")?,
-        })
+            meta: Meta::new_lossy("Not found"),
+        }
     }
 
-    pub fn client_certificate_required() -> Result<Self> {
-        Ok(Self {
+    pub fn client_certificate_required() -> Self {
+        Self {
             status: Status::CLIENT_CERTIFICATE_REQUIRED,
-            meta: Meta::new("No certificate provided")?,
-        })
+            meta: Meta::new_lossy("No certificate provided"),
+        }
     }
 
-    pub fn certificate_not_authorized() -> Result<Self> {
-        Ok(Self {
+    pub fn certificate_not_authorized() -> Self {
+        Self {
             status: Status::CERTIFICATE_NOT_AUTHORIZED,
-            meta: Meta::new("Your certificate is not authorized to view this content")?,
-        })
+            meta: Meta::new_lossy("Your certificate is not authorized to view this content"),
+        }
     }
 
     pub fn status(&self) -> &Status {
@@ -272,9 +286,14 @@ impl Response {
         Ok(Self::new(header))
     }
 
-    pub fn success(mime: &Mime) -> Result<Self> {
-        let header = ResponseHeader::success(&mime)?;
-        Ok(Self::new(header))
+    pub fn input_lossy(prompt: impl AsRef<str> + Into<String>) -> Self {
+        let header = ResponseHeader::input_lossy(prompt);
+        Self::new(header)
+    }
+
+    pub fn success(mime: &Mime) -> Self {
+        let header = ResponseHeader::success(&mime);
+        Self::new(header)
     }
 
     pub fn server_error(reason: impl AsRef<str> + Into<String>) -> Result<Self>  {
@@ -282,19 +301,19 @@ impl Response {
         Ok(Self::new(header))
     }
 
-    pub fn not_found() -> Result<Self> {
-        let header = ResponseHeader::not_found()?;
-        Ok(Self::new(header))
+    pub fn not_found() -> Self {
+        let header = ResponseHeader::not_found();
+        Self::new(header)
     }
 
-    pub fn client_certificate_required() -> Result<Self> {
-        let header = ResponseHeader::client_certificate_required()?;
-        Ok(Self::new(header))
+    pub fn client_certificate_required() -> Self {
+        let header = ResponseHeader::client_certificate_required();
+        Self::new(header)
     }
 
-    pub fn certificate_not_authorized() -> Result<Self> {
-        let header = ResponseHeader::certificate_not_authorized()?;
-        Ok(Self::new(header))
+    pub fn certificate_not_authorized() -> Self {
+        let header = ResponseHeader::certificate_not_authorized();
+        Self::new(header)
     }
 
     pub fn with_body(mut self, body: impl Into<Body>) -> Self {

--- a/src/util.rs
+++ b/src/util.rs
@@ -15,12 +15,12 @@ pub async fn serve_file<P: AsRef<Path>>(path: P, mime: &Mime) -> Result<Response
     let file = match File::open(path).await {
         Ok(file) => file,
         Err(err) => match err.kind() {
-            io::ErrorKind::NotFound => return Ok(Response::not_found()?),
+            io::ErrorKind::NotFound => return Ok(Response::not_found()),
             _ => return Err(err.into()),
         }
     };
 
-    Ok(Response::success(&mime)?.with_body(file))
+    Ok(Response::success(&mime).with_body(file))
 }
 
 pub async fn serve_dir<D: AsRef<Path>, P: AsRef<Path>>(dir: D, virtual_path: &[P]) -> Result<Response> {
@@ -35,7 +35,7 @@ pub async fn serve_dir<D: AsRef<Path>, P: AsRef<Path>>(dir: D, virtual_path: &[P
     let path = path.canonicalize()?;
 
     if !path.starts_with(&dir) {
-        return Ok(Response::not_found()?);
+        return Ok(Response::not_found());
     }
 
     if !path.is_dir() {
@@ -52,7 +52,7 @@ async fn serve_dir_listing<P: AsRef<Path>, B: AsRef<Path>>(path: P, virtual_path
     let mut dir = match fs::read_dir(path).await {
         Ok(dir) => dir,
         Err(err) => match err.kind() {
-            io::ErrorKind::NotFound => return Ok(Response::not_found()?),
+            io::ErrorKind::NotFound => return Ok(Response::not_found()),
             _ => return Err(err.into()),
         }
     };
@@ -82,7 +82,7 @@ async fn serve_dir_listing<P: AsRef<Path>, B: AsRef<Path>>(path: P, virtual_path
         )?;
     }
 
-    Ok(Response::success(&GEMINI_MIME)?.with_body(listing))
+    Ok(Response::success(&GEMINI_MIME).with_body(listing))
 }
 
 pub fn guess_mime_from_path<P: AsRef<Path>>(path: P) -> Mime {


### PR DESCRIPTION
Reduce the number of fallible constructors due to `Meta::new`. This is achieved by introducing `Meta::new_lossy`, which truncates meta strings to conform to the spec.

Closes #7 

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/panicbit/northstar/8)
<!-- Reviewable:end -->
