### PR TITLE
Add Response::success_with_body

### DIFF
--- a/examples/certificates.rs
+++ b/examples/certificates.rs
@@ -37,8 +37,10 @@ fn handle_request(users: Arc<RwLock<HashMap<CertBytes, String>>>, request: Reque
             if let Some(user) = users_read.get(cert_bytes) {
                 // The user has already registered
                 Ok(
-                    Response::success(&GEMINI_MIME)
-                        .with_body(format!("Welcome {}!", user))
+                    Response::success_with_body(
+                        &GEMINI_MIME,
+                        format!("Welcome {}!", user)
+                    )
                 )
             } else {
                 // The user still needs to register
@@ -49,11 +51,13 @@ fn handle_request(users: Arc<RwLock<HashMap<CertBytes, String>>>, request: Reque
                     let mut users_write = users.write().await;
                     users_write.insert(cert_bytes.clone(), username.to_owned());
                     Ok(
-                        Response::success(&GEMINI_MIME)
-                            .with_body(format!(
+                        Response::success_with_body(
+                            &GEMINI_MIME,
+                            format!(
                                 "Your account has been created {}!  Welcome!",
                                 username
-                            ))
+                            )
+                        )
                     )
                 } else {
                     // The user didn't provide input, and should be prompted

--- a/src/types/response.rs
+++ b/src/types/response.rs
@@ -17,7 +17,7 @@ impl Response {
     }
 
     pub fn document(document: Document) -> Self {
-        Self::success(&GEMINI_MIME).with_body(document)
+        Self::success_with_body(&GEMINI_MIME, document)
     }
 
     pub fn input(prompt: impl Cowy<str>) -> Result<Self> {
@@ -33,6 +33,19 @@ impl Response {
     pub fn success(mime: &Mime) -> Self {
         let header = ResponseHeader::success(&mime);
         Self::new(header)
+    }
+
+    /// Create a successful response with a preconfigured body
+    ///
+    /// This is equivilent to:
+    ///
+    /// ```norun
+    /// Response::success(mime)
+    ///     .with_body(body)
+    /// ```
+    pub fn success_with_body(mime: &Mime, body: impl Into<Body>) -> Self {
+        Self::success(mime)
+            .with_body(body)
     }
 
     pub fn server_error(reason: impl Cowy<str>) -> Result<Self>  {

--- a/src/util.rs
+++ b/src/util.rs
@@ -20,7 +20,7 @@ pub async fn serve_file<P: AsRef<Path>>(path: P, mime: &Mime) -> Result<Response
         }
     };
 
-    Ok(Response::success(&mime).with_body(file))
+    Ok(Response::success_with_body(mime, file))
 }
 
 pub async fn serve_dir<D: AsRef<Path>, P: AsRef<Path>>(dir: D, virtual_path: &[P]) -> Result<Response> {


### PR DESCRIPTION
This is a super simple method that just combines Response::success and Response::with_body into a single method.  I found that a lot of the time I was creating a Response, I was immediately adding the body, but the existing method created a little bit of messy code.  Hopefully this will help to clean that up a bit

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/panicbit/northstar/18)
<!-- Reviewable:end -->
