### PR TITLE
Add a special case timeout override

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 ### Added
 - `document` API for creating Gemini documents
-- preliminary timeout API by [@Alch-Emi](https://github.com/Alch-Emi)
+- preliminary timeout API, incl a special case for complex MIMEs by [@Alch-Emi](https://github.com/Alch-Emi)
 - `Response::success_with_body` by [@Alch-Emi](https://github.com/Alch-Emi)
 - `redirect_temporary_lossy` for `Response` and `ResponseHeader`
 - `bad_request_lossy` for `Response` and `ResponseHeader`

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -139,7 +139,12 @@ impl<A: ToSocketAddrs> Builder<A> {
     /// If you would like a timeout for your code itself, please use
     /// [`tokio::time::Timeout`] to implement it internally.
     ///
-    /// The default timeout is 30 seconds.
+    /// **The default timeout is 30 seconds.**  If you are considering changing this, keep
+    /// in mind that some clients, when recieving a file type not supported for display,
+    /// will prompt the user how they would like to proceed.  While this occurs, the
+    /// request hangs open.  Setting a short timeout may close the prompt before user has
+    /// a chance to respond.  If you are only serving `text/plain` and `text/gemini`, this
+    /// should not be a problem.
     pub fn set_timeout(mut self, timeout: Duration) -> Self {
         self.timeout = timeout;
         self

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -122,7 +122,7 @@ impl Server {
         // All the other code is doing one of two things.  Either it's
         //
         // * code to add and handle timeouts (that's what all the async blocks and calls
-        //   to tokio::time::timeout are), or
+        //   to timeout are), or
         // * logic to decide whether to use the special case timeout handling (seperate
         //   timeouts for the header and the body) vs the normal timeout handling (header,
         //   body, and flush all as one timeout)
@@ -151,7 +151,7 @@ impl Server {
                             .await
                             .context("Failed to flush response header")
                     };
-                    tokio::time::timeout(self.timeout, fut_send_header)
+                    timeout(self.timeout, fut_send_header)
                         .await
                         .context("Timed out while sending response header")??;
 
@@ -164,7 +164,7 @@ impl Server {
                             .await
                             .context("Failed to flush response body")
                     };
-                    tokio::time::timeout(cplx_timeout, fut_send_body)
+                    timeout(cplx_timeout, fut_send_body)
                         .await
                         .context("Timed out while sending response body")??;
 
@@ -189,7 +189,7 @@ impl Server {
                 .await
                 .context("Failed to flush response data")
         };
-        tokio::time::timeout(self.timeout, fut_send_response)
+        timeout(self.timeout, fut_send_response)
             .await
             .context("Timed out while sending response data")??;
 


### PR DESCRIPTION
This addresses some of the concerns raised in #22.

In an effort to keep timeouts low and improve server performance while still allowing clients to allow downloading a file only after a prompt, an extended timeout override is only used in situations where a client may not be able to handle the mime type of the received file, and is only applied to the sending of the body of the request.  The response header and the request still use the normal timeout.

This is completely configurable, including turning it off, in the Server builder.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/panicbit/northstar/24)
<!-- Reviewable:end -->
