### PR TITLE
Allow direct conversion for Document -> Response

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,15 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 ### Added
 - `document` API for creating Gemini documents
-- preliminary timeout API, incl a special case for complex MIMEs by [@Alch-Emi](https://github.com/Alch-Emi)
-- `Response::success_with_body` by [@Alch-Emi](https://github.com/Alch-Emi)
+- preliminary timeout API, incl a special case for complex MIMEs by [@Alch-Emi]
+- `Response::success_with_body` by [@Alch-Emi]
 - `redirect_temporary_lossy` for `Response` and `ResponseHeader`
 - `bad_request_lossy` for `Response` and `ResponseHeader`
 - support for a lot more mime-types in `guess_mime_from_path`, backed by the `mime_guess` crate
-- customizable TLS cert & key paths by [@Alch-Emi](https://github.com/Alch-Emi)
-- `server_dir` default feature for serve_dir utils [@Alch-Emi](https://github.com/Alch-Emi)
+- customizable TLS cert & key paths by [@Alch-Emi]
+- `server_dir` default feature for serve_dir utils [@Alch-Emi]
+- Docments can be converted into responses with std::convert::Into [@Alch-Emi]
 ### Improved
-- build time and size by [@Alch-Emi](https://github.com/Alch-Emi)
+- build time and size by [@Alch-Emi]
 
 ## [0.3.0] - 2020-11-14
 ### Added
@@ -34,4 +35,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [0.2.0] - 2020-11-14
 ### Added
-- Access to client certificates by [@Alch-Emi](https://github.com/Alch-Emi)
+- Access to client certificates by [@Alch-Emi]
+
+[@Alch-Emi]: https://github.com/Alch-Emi

--- a/examples/document.rs
+++ b/examples/document.rs
@@ -18,9 +18,7 @@ async fn main() -> Result<()> {
 
 fn handle_request(_request: Request) -> BoxFuture<'static, Result<Response>> {
     async move {
-        let mut document = Document::new();
-
-        document
+        let response = Document::new()
             .add_preformatted(include_str!("northstar_logo.txt"))
             .add_blank_line()
             .add_link("https://docs.rs/northstar", "Documentation")
@@ -43,9 +41,9 @@ fn handle_request(_request: Request) -> BoxFuture<'static, Result<Response>> {
             .add_preformatted_with_alt("sh", concat!(
                 "mkdir cert && cd cert\n",
                 "openssl req -x509 -nodes -newkey rsa:4096 -keyout key.pem -out cert.pem -days 365",
-            ));
-
-        Ok(Response::document(document))
+            ))
+            .into();
+        Ok(response)
     }
     .boxed()
 }

--- a/src/types/body.rs
+++ b/src/types/body.rs
@@ -2,6 +2,8 @@ use tokio::io::AsyncRead;
 #[cfg(feature="serve_dir")]
 use tokio::fs::File;
 
+use std::borrow::Borrow;
+
 use crate::types::Document;
 
 pub enum Body {
@@ -9,9 +11,9 @@ pub enum Body {
     Reader(Box<dyn AsyncRead + Send + Sync + Unpin>),
 }
 
-impl From<Document> for Body {
-    fn from(document: Document) -> Self {
-        Self::from(document.to_string())
+impl<D: Borrow<Document>> From<D> for Body {
+    fn from(document: D) -> Self {
+        Self::from(document.borrow().to_string())
     }
 }
 

--- a/src/types/response.rs
+++ b/src/types/response.rs
@@ -1,4 +1,5 @@
 use std::convert::TryInto;
+use std::borrow::Borrow;
 
 use anyhow::*;
 use uriparse::URIReference;
@@ -19,7 +20,7 @@ impl Response {
         }
     }
 
-    pub fn document(document: Document) -> Self {
+    pub fn document(document: impl Borrow<Document>) -> Self {
         Self::success_with_body(&GEMINI_MIME, document)
     }
 

--- a/src/types/response.rs
+++ b/src/types/response.rs
@@ -95,3 +95,9 @@ impl Response {
         self.body.take()
     }
 }
+
+impl<D: Borrow<Document>> From<D> for Response {
+    fn from(doc: D) -> Self {
+        Self::document(doc)
+    }
+}


### PR DESCRIPTION
This add `From<Borrow<Document>>` to Response, allowing users to call `.into()` on any reference to a Document.  This means that when chaining methods together to build a document, `.into()` can simply be chained along.  So this:

```rust
let doc = Document::new();
doc.add_text("hello")
   .add_text("world");
let resp = Response::document(doc);
```

can become this:

```rust
let resp = Document::new()
    .add_text("hello")
    .add_text("wello")
    .into();
```

This does also affect the Response::document method, but only to make it more general, so this isn't a breaking change.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/panicbit/northstar/30)
<!-- Reviewable:end -->
