### PR TITLE
Rework Request::success methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - `document` API for creating Gemini documents
 - preliminary timeout API, incl a special case for complex MIMEs by [@Alch-Emi]
-- `Response::success_with_body` by [@Alch-Emi]
+- `Response::success_*` variants by [@Alch-Emi]
 - `redirect_temporary_lossy` for `Response` and `ResponseHeader`
 - `bad_request_lossy` for `Response` and `ResponseHeader`
 - support for a lot more mime-types in `guess_mime_from_path`, backed by the `mime_guess` crate
@@ -17,6 +17,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Docments can be converted into responses with std::convert::Into [@Alch-Emi]
 ### Improved
 - build time and size by [@Alch-Emi]
+### Changed
+- `Response::success` now takes a request body [@Alch-Emi]
 
 ## [0.3.0] - 2020-11-14
 ### Added

--- a/examples/certificates.rs
+++ b/examples/certificates.rs
@@ -3,7 +3,7 @@ use futures_core::future::BoxFuture;
 use futures_util::FutureExt;
 use log::LevelFilter;
 use tokio::sync::RwLock;
-use northstar::{Certificate, GEMINI_MIME, GEMINI_PORT, Request, Response, Server};
+use northstar::{Certificate, GEMINI_PORT, Request, Response, Server};
 use std::collections::HashMap;
 use std::sync::Arc;
 
@@ -38,8 +38,7 @@ fn handle_request(users: Arc<RwLock<HashMap<CertBytes, String>>>, request: Reque
             if let Some(user) = users_read.get(cert_bytes) {
                 // The user has already registered
                 Ok(
-                    Response::success_with_body(
-                        &GEMINI_MIME,
+                    Response::success_gemini(
                         format!("Welcome {}!", user)
                     )
                 )
@@ -52,8 +51,7 @@ fn handle_request(users: Arc<RwLock<HashMap<CertBytes, String>>>, request: Reque
                     let mut users_write = users.write().await;
                     users_write.insert(cert_bytes.clone(), username.to_owned());
                     Ok(
-                        Response::success_with_body(
-                            &GEMINI_MIME,
+                        Response::success_gemini(
                             format!(
                                 "Your account has been created {}!  Welcome!",
                                 username

--- a/src/util.rs
+++ b/src/util.rs
@@ -28,7 +28,7 @@ pub async fn serve_file<P: AsRef<Path>>(path: P, mime: &Mime) -> Result<Response
         }
     };
 
-    Ok(Response::success_with_body(mime, file))
+    Ok(Response::success(mime, file))
 }
 
 #[cfg(feature="serve_dir")]
@@ -93,7 +93,7 @@ async fn serve_dir_listing<P: AsRef<Path>, B: AsRef<Path>>(path: P, virtual_path
         ));
     }
 
-    Ok(Response::document(document))
+    Ok(document.into())
 }
 
 #[cfg(feature="serve_dir")]


### PR DESCRIPTION
It was discussed in #19 that we may want to consider changing the API surrounding creating successful request objects, as the current API is somewhat clumsy.  This PR is one possible alternative.

The following methods are included:
- `Response::success(mime: &mime::Mime, body: impl Into<Body>)` - The generic success method, equivalent to the existing `success_with_body()` method.
-  `Response::success_gemini(body: impl Into<Body>)` - Creates a response pre-configured with the `text/gemini` mime type.  A lot of interfaces will be communicating with the user using the native gemini format, so it makes sense to have a method that saves the user from going through the whole process with the `&GEMINI_MIME`, which could easily be a small stumbling box for new users.
- `Response::success_plain(body: impl Into<Body>)` - The same as the above, but with `text/plain`

This also deprecates `Response::document()` in favor of `Document::into()` or `Response::success_gemini()`

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/panicbit/northstar/33)
<!-- Reviewable:end -->
