### PR TITLE
Improve error handling for serve_dir

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Docments can be converted into responses with std::convert::Into [@Alch-Emi]
 ### Improved
 - build time and size by [@Alch-Emi]
+- Improved error handling in serve_dir [@Alch-Emi]
 
 ## [0.3.0] - 2020-11-14
 ### Added


### PR DESCRIPTION
There seems to be a bit of a bug where any errors that occur in the serve_dir method are propegated up to the default error handler, resulting in the client receiving SERVER_ERRORs for all cases, even ones that should be handled by a simple NOT_FOUND.  This also prints a bunch of log-cluttering anyhow errors to the log for routine errors.  This PR improves error handling by tailoring the response sent to the client by scenario, and printing more useful warnings to the log.

Specifically:
 - Serve NOT_FOUND when file or directory doesn't exist
 - Serve NOT_FOUND and warn in log when permission denied for file or directory
 - Serve SERVER_ERROR("Server misconfigured") and warn in log when permission denied or not found for path to serve from
 - Serve SERVER_ERROR("Unexpected error") and warn in log with a link to the GH if an unexpected error happens

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/panicbit/northstar/34)
<!-- Reviewable:end -->
