### PR TITLE
Add "serve_dir" feature as a required feature for the example of the same name

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,3 +30,7 @@ mime_guess = { version = "2.0.3", optional = true }
 env_logger = "0.8.1"
 futures-util = "0.3.7"
 tokio = { version = "0.3.1", features = ["macros", "rt-multi-thread", "sync"] }
+
+[[example]]
+name = "serve_dir"
+required-features = ["serve_dir"]


### PR DESCRIPTION
Right now, running `cargo test --no-default-features` fails because it forgets to turn on the `serve_dir` feature for the `serve_dir` example.  Similarly, running `cargo run --example serve_dir --no-default-features` crashes with a build error instead of the normal "hey you gotta enable the feature to run the test" message.

This can be fixed by listing the `serve_dir` example in `Cargo.toml`

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/panicbit/northstar/35)
<!-- Reviewable:end -->
